### PR TITLE
Add ruff to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "ruff>=0.1",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary
- include `ruff>=0.1` in `pyproject.toml` dev optional dependencies

## Testing
- `pip install -e .[dev]`
- `pytest tests/test_hello.py -q`
- `pytest -q` *(fails: Error creating container: Failed to establish a new connection)*

------
https://chatgpt.com/codex/tasks/task_e_687b5aa3c0f0832f9bccf86ccb82ddc9