### PR TITLE
Add AGENTS instructions for Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENT Instructions for AI coding tools
+
+This project already provides environment details for GitHub's coding agent in
+[AI_ENVIRONMENT.md](AI_ENVIRONMENT.md). Codex expects an `AGENTS.md` file to
+locate similar guidance. This file points both agents to the same instructions.
+
+## Quick Setup
+
+Use Python 3.12. Install dependencies and run tests with:
+
+```bash
+pip install -e ".[dev]" && pytest
+```
+
+For coverage information, run:
+
+```bash
+pytest --cov=actions_package --cov-report=term-missing -v
+```
+
+See the **AI_ENVIRONMENT.md** document for complete environment and workflow
+information.

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ actions/
 For AI coding agents and developers, this repository provides comprehensive environment documentation:
 
 - **📋 [DEVELOPMENT.md](DEVELOPMENT.md)** - Complete development guide with build details
+- **📑 [AGENTS.md](AGENTS.md)** - Instructions for Codex and GitHub's coding agent
 - **🤖 [AI_ENVIRONMENT.md](AI_ENVIRONMENT.md)** - Quick reference for AI coding agents
 - **🐳 [Dockerfile](Dockerfile)** - Reproducible container environment
 - **⚙️ [dev-setup.sh](dev-setup.sh)** - Automated development setup script


### PR DESCRIPTION
## Summary
- add an `AGENTS.md` file so Codex has repository instructions
- link to this new file from README

## Testing
- `pip install -e ".[dev]"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f9bf33fd0832fbe1b4376a5efe6a9