### PR TITLE
Fix Azurite env for icechunk tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 import shutil
 import socket
 import time
@@ -45,6 +46,25 @@ def pytest_sessionstart(session: pytest.Session) -> None:  # noqa: D401
     session.config.azurite_process = process
     if process is None:
         print("Warning: Azurite could not be started. Tests may fail.")
+
+
+@pytest.fixture(autouse=True)
+def azurite_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide default Azurite credentials via environment variables."""
+    connection = (
+        "DefaultEndpointsProtocol=http;"
+        "AccountName=devstoreaccount1;"
+        "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
+        "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+    )
+
+    monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", connection)
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "devstoreaccount1")
+    monkeypatch.setenv(
+        "AZURE_STORAGE_ACCOUNT_KEY",
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
+    )
+    monkeypatch.setenv("AZURITE_BLOB_STORAGE_URL", "http://127.0.0.1:10000")
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:  # noqa: D401

--- a/tests/test_azurite_service.py
+++ b/tests/test_azurite_service.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import xarray as xr
 import zarr
@@ -40,7 +41,23 @@ def test_azure_icechunk():
     """ Use icechunk to write a file to azure storage, emulated by Azurite"""
 
     import icechunk
+    client = AzuriteStorageClient()
+    client.container_name = "my-container"
+    try:
+        client.blob_service_client.delete_container(client.container_name)
+    except Exception:
+        pass
+    client.create_container()
 
-    storage = icechunk.azure_storage(container="my-container", prefix="my-prefix", from_env=True)
+    storage = icechunk.azure_storage(
+        account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
+        container="my-container",
+        prefix="my-prefix",
+        from_env=True,
+        config={
+            "azure_storage_use_emulator": "true",
+            "azure_allow_http": "true",
+        },
+    )
     repo = icechunk.Repository.create(storage)
 


### PR DESCRIPTION
## Summary
- expose default Azurite credentials via pytest fixture
- create/delete container in `test_azure_icechunk`
- configure icechunk to talk to the Azurite emulator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fc6c54998832f80553469e853812e