### PR TITLE
Add bandwidth measurement utilities to Azurite tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "fsspec>=2024.1.0",
     "adlfs>=2024.1.0",  # Azure Data Lake filesystem for fsspec
     "icechunk>=1.0.0",
+    "dask[array]>=2024.1.0",
     "netCDF4>=1.5.0",
 ]
 
@@ -36,6 +37,7 @@ dev = [
     "mypy>=1.0",    # Type checking
     "numpy>=1.24.0",  # Required by tests
     "tox>=4.0",     # Testing across environments
+    "psutil>=5.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,51 @@
+# Helper functions for tests involving Azurite and icechunk
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import psutil
+
+from actions_package.azure_storage import AzuriteStorageClient
+
+
+def get_test_data_path() -> Path:
+    """Return path to small test dataset."""
+    return Path(__file__).resolve().parent / "data" / "small_data.nc"
+
+
+def setup_icechunk_repo(container_name: str, prefix: str):
+    """Create an icechunk repository in a new Azurite container."""
+    import icechunk
+
+    client = AzuriteStorageClient()
+    client.container_name = container_name
+    try:
+        client.blob_service_client.delete_container(client.container_name)
+    except Exception:
+        pass
+    client.create_container()
+
+    storage = icechunk.azure_storage(
+        account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
+        container=client.container_name,
+        prefix=prefix,
+        from_env=True,
+        config={
+            "azure_storage_use_emulator": "true",
+            "azure_allow_http": "true",
+        },
+    )
+    return icechunk.Repository.create(storage)
+
+
+def total_net_bytes(interface: Optional[str] = None) -> int:
+    """Return total bytes sent+received on the given interface."""
+    counters = psutil.net_io_counters(pernic=True)
+    if interface:
+        stat = counters.get(interface)
+        if stat is None:
+            return 0
+        return stat.bytes_sent + stat.bytes_recv
+    return sum(c.bytes_sent + c.bytes_recv for c in counters.values())

--- a/tests/test_azurite_service.py
+++ b/tests/test_azurite_service.py
@@ -1,12 +1,13 @@
 import os
-from pathlib import Path
 import fsspec
+import xarray as xr
+import icechunk
+import icechunk.xarray as icx
+
 from actions_package.azure_storage import AzuriteStorageClient
+from actions_package.mock_data_generator import generate_mock_data
 
-
-def get_test_data_path():
-    """Get the path to the test data file"""
-    return Path(__file__).resolve().parent / "data" / "small_data.nc"
+from tests.helpers import get_test_data_path, setup_icechunk_repo, total_net_bytes
 
 
 def test_azurite_basic_operations():
@@ -23,125 +24,60 @@ def test_azurite_basic_operations():
 
 
 def test_azure_fsspec():
-    """ Use fsspec to write a file to azure storage, emulated by Azurite"""
-    CONN_STRING = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+    """Use fsspec to write a file to azure storage via Azurite."""
+    CONN_STRING = (
+        "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"
+        "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;"
+        "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+    )
 
-    fs = fsspec.filesystem("filecache", target_protocol="az",
-        target_options={'connection_string': CONN_STRING})
+    fs = fsspec.filesystem("filecache", target_protocol="az", target_options={"connection_string": CONN_STRING})
 
     fs.rm("test-container")
-    fs.mkdir("test-container") # ok
+    fs.mkdir("test-container")  # ok
 
     assert len(fs.ls("test-container")) == 0
 
     with fs.open("test-container/foo", mode="wb") as file_handle:
-        file_handle.write(b"foo") # ok
+        file_handle.write(b"foo")
 
     assert len(fs.ls("test-container")) == 1
 
 
 def test_azure_icechunk():
-    """ Use icechunk to write a file to azure storage, emulated by Azurite"""
-
-    import icechunk
-    client = AzuriteStorageClient()
-    client.container_name = "my-container"
-    try:
-        client.blob_service_client.delete_container(client.container_name)
-    except Exception:
-        pass
-    client.create_container()
-
-    storage = icechunk.azure_storage(
-        account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
-        container="my-container",
-        prefix="my-prefix",
-        from_env=True,
-        config={
-            "azure_storage_use_emulator": "true",
-            "azure_allow_http": "true",
-        },
-    )
-    repo = icechunk.Repository.create(storage)
-    
-    # Verify repository was created successfully
+    """Create an empty icechunk repository on Azurite."""
+    repo = setup_icechunk_repo("my-container", "my-prefix")
     assert repo is not None
 
 
 def test_azure_icechunk_xarray_upload(tmp_path):
     """Upload a NetCDF file to Azurite via icechunk using xarray."""
-
-    import icechunk
-    import icechunk.xarray as icx
-    import xarray as xr
-
-    client = AzuriteStorageClient()
-    client.container_name = "xarray-container"
-    try:
-        client.blob_service_client.delete_container(client.container_name)
-    except Exception:
-        pass
-    client.create_container()
-
-    storage = icechunk.azure_storage(
-        account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
-        container=client.container_name,
-        prefix="xarray-prefix",
-        from_env=True,
-        config={
-            "azure_storage_use_emulator": "true",
-            "azure_allow_http": "true",
-        },
-    )
-    repo = icechunk.Repository.create(storage)
+    repo = setup_icechunk_repo("xarray-container", "xarray-prefix")
 
     session = repo.writable_session("main")
     ds = xr.open_dataset(get_test_data_path())
+    start_bytes = total_net_bytes()
     icx.to_icechunk(ds, session, mode="w")
     session.commit("initial upload")
+    used = total_net_bytes() - start_bytes
 
     ro = repo.readonly_session("main")
     result = xr.open_dataset(ro.store, engine="zarr")
 
     assert len(result["timestamp"]) == len(ds["timestamp"])
     assert len(result["high_res_timestamp"]) == len(ds["high_res_timestamp"])
+    assert used > 0
 
 
 def test_azure_icechunk_append(tmp_path):
     """Append extended data to an existing icechunk store."""
+    repo = setup_icechunk_repo("append-container", "append-prefix")
 
-    import icechunk
-    import icechunk.xarray as icx
-    import xarray as xr
-    from actions_package.mock_data_generator import generate_mock_data
-
-    client = AzuriteStorageClient()
-    client.container_name = "append-container"
-    try:
-        client.blob_service_client.delete_container(client.container_name)
-    except Exception:
-        pass
-    client.create_container()
-
-    storage = icechunk.azure_storage(
-        account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
-        container=client.container_name,
-        prefix="append-prefix",
-        from_env=True,
-        config={
-            "azure_storage_use_emulator": "true",
-            "azure_allow_http": "true",
-        },
-    )
-    repo = icechunk.Repository.create(storage)
-
-    # Initial upload
     base_session = repo.writable_session("main")
     ds_seed = xr.open_dataset(get_test_data_path())
     icx.to_icechunk(ds_seed, base_session, mode="w")
     base_session.commit("initial")
 
-    # Generate extended dataset
     extended_path = tmp_path / "extended.nc"
     ds_extended = generate_mock_data(
         seed_file=get_test_data_path(),
@@ -149,7 +85,8 @@ def test_azure_icechunk_append(tmp_path):
         target_size_mb=10,
     )
 
-    # Append new timestamp data
+    start_bytes = total_net_bytes()
+
     ts_slice = slice(len(ds_seed["timestamp"]), None)
     ds_ts = ds_extended.isel(timestamp=ts_slice)
     ds_ts = ds_ts[[v for v in ds_ts.data_vars if "timestamp" in ds_ts[v].dims]]
@@ -158,7 +95,6 @@ def test_azure_icechunk_append(tmp_path):
     icx.to_icechunk(ds_ts, ts_session, append_dim="timestamp")
     ts_session.commit("append timestamp")
 
-    # Append new high resolution timestamp data
     hr_slice = slice(len(ds_seed["high_res_timestamp"]), None)
     ds_hr = ds_extended.isel(high_res_timestamp=hr_slice)
     ds_hr = ds_hr[[v for v in ds_hr.data_vars if "high_res_timestamp" in ds_hr[v].dims]]
@@ -166,10 +102,11 @@ def test_azure_icechunk_append(tmp_path):
     icx.to_icechunk(ds_hr, hr_session, append_dim="high_res_timestamp")
     hr_session.commit("append highres")
 
+    used = total_net_bytes() - start_bytes
+
     ro = repo.readonly_session("main")
     result = xr.open_dataset(ro.store, engine="zarr")
 
     assert len(result["timestamp"]) == len(ds_extended["timestamp"])
     assert len(result["high_res_timestamp"]) == len(ds_extended["high_res_timestamp"])
-
-
+    assert used > 0


### PR DESCRIPTION
## Summary
- refactor Azurite tests and extract helpers for repo creation
- add psutil based utility to capture network IO
- verify network bytes transferred during upload and append
- install dask and psutil in dev environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883772ab278832f97df8b880cb9d5b9