### PR TITLE
Add streaming blocks helper test

### DIFF
--- a/src/actions_package/azure_storage.py
+++ b/src/actions_package/azure_storage.py
@@ -104,16 +104,23 @@ class AzuriteStorageClient:
             print(f"Error downloading blob: {e}")
             return None
     
-    def list_blobs(self) -> list[str]:
+    def list_blobs(self, name_starts_with: str | None = None) -> list[str]:
         """
-        List all blobs in the container.
-        
-        Returns:
-            List of blob names.
+        List blobs in the container.
+
+        Parameters
+        ----------
+        name_starts_with : str | None
+            Optional prefix for filtering blob names.
+
+        Returns
+        -------
+        list[str]
+            Names of blobs found in the container.
         """
         try:
             container_client = self.blob_service_client.get_container_client(self.container_name)
-            blobs = container_client.list_blobs()
+            blobs = container_client.list_blobs(name_starts_with=name_starts_with)
             return [blob.name for blob in blobs]
         except Exception as e:
             print(f"Error listing blobs: {e}")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -49,3 +49,18 @@ def total_sent_bytes(interface: Optional[str] = None) -> int:
             return 0
         return stat.bytes_sent
     return sum(c.bytes_sent for c in counters.values())
+
+def find_latest_backup_repo(container_name: str, backup_root: str = "backup") -> list[str]:
+    """Return backup repository prefixes in creation order."""
+    client = AzuriteStorageClient()
+    client.container_name = container_name
+    blob_names = client.list_blobs(name_starts_with=f"{backup_root}/")
+    prefixes: set[str] = set()
+    for name in blob_names:
+        parts = name.split("/", 2)
+        if len(parts) >= 2:
+            prefixes.add(parts[1])
+    if not prefixes:
+        raise FileNotFoundError("No backup repositories found")
+    timestamps = sorted(prefixes)
+    return [f"{backup_root}/{ts}" for ts in timestamps]

--- a/tests/test_streaming_blocks.py
+++ b/tests/test_streaming_blocks.py
@@ -1,0 +1,66 @@
+import os
+import time
+from datetime import datetime
+
+import icechunk
+import icechunk.xarray as icx
+import xarray as xr
+
+from actions_package.azure_storage import AzuriteStorageClient
+from tests.helpers import get_test_data_path, find_latest_backup_repo
+
+
+def _create_backup_repo(container_name: str, prefix: str, dataset: xr.Dataset) -> None:
+    """Create a new icechunk repository in *container_name* under *prefix*."""
+    client = AzuriteStorageClient()
+    client.container_name = container_name
+    client.create_container()
+
+    storage = icechunk.azure_storage(
+        account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
+        container=container_name,
+        prefix=prefix,
+        from_env=True,
+        config={
+            "azure_storage_use_emulator": "true",
+            "azure_allow_http": "true",
+        },
+    )
+    repo = icechunk.Repository.create(storage)
+    session = repo.writable_session("main")
+    icx.to_icechunk(dataset, session, mode="w")
+    session.commit("initial upload")
+
+
+def test_find_latest_backup_repo():
+    """Ensure the latest backup repository can be located and opened."""
+    container = "streaming-backup"
+    ds = xr.open_dataset(get_test_data_path())
+    prefixes = []
+
+    for _ in range(3):
+        ts = datetime.utcnow().strftime("%Y%m%d%H%M%S%f")
+        prefix = f"backup/{ts}"
+        _create_backup_repo(container, prefix, ds)
+        prefixes.append(prefix)
+        time.sleep(0.01)  # ensure unique timestamps
+
+    repos = find_latest_backup_repo(container)
+    assert repos == sorted(prefixes)
+    latest = repos[-1]
+
+    storage = icechunk.azure_storage(
+        account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
+        container=container,
+        prefix=latest,
+        from_env=True,
+        config={
+            "azure_storage_use_emulator": "true",
+            "azure_allow_http": "true",
+        },
+    )
+    repo = icechunk.Repository.open(storage)
+    ro = repo.readonly_session("main")
+    loaded = xr.open_dataset(ro.store, engine="zarr")
+
+    assert len(loaded["timestamp"]) == len(ds["timestamp"])


### PR DESCRIPTION
## Summary
- add helper to locate newest backup repo in Azurite
- create `test_streaming_blocks.py` verifying the helper
- allow listing blobs by prefix and return all repos chronologically

## Testing
- `pip install -e .[dev]`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6884ee828224832f9dc8cc616d7a6019