### PR TITLE
Add pytest artifact collection fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[codz]
 *$py.class
 
+# Test run artifacts
+artifacts/
+
 # C extensions
 *.so
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -108,6 +108,21 @@ pytest tests/test_hello.py::TestHelloWorld
 pytest tests/test_hello.py::TestHelloWorld::test_hello_world_default
 ```
 
+### Collecting Test Artifacts
+
+Tests can record files such as generated data or plots using the
+`artifacts` fixture. Files saved through this fixture are copied to an
+`artifacts/` directory and a `manifest.json` file is written containing the
+size of each artifact. The manifest is created even when a test fails so that
+CI systems can inspect the results.
+
+Example:
+
+```python
+def test_example(artifacts):
+    artifacts.save_text("output.txt", "content")
+```
+
 ### Current Test Coverage
 
 - **Total Coverage**: ~69%

--- a/tests/test_artifacts_fixture.py
+++ b/tests/test_artifacts_fixture.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import json
+
+
+def test_artifact_fixture_writes_manifest(artifacts):
+    artifacts.save_text("example.txt", "hi")
+    manifest = artifacts.finalize()
+    assert manifest["example.txt"] == 2
+    manifest_path = artifacts.path / "manifest.json"
+    data = json.loads(manifest_path.read_text())
+    assert data["example.txt"] == 2


### PR DESCRIPTION
## Summary
- add `ArtifactCollector` and `artifacts` fixture for saving test outputs and logging sizes
- document artifact collection workflow in development guide
- ignore generated `artifacts/` directory and add a regression test

## Testing
- `pip install -e ".[dev]"`
- `pytest` *(fails: azurite connection errors)*
- `pytest tests/test_artifacts_fixture.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a20592f90832fbf33391ded75453b