### PR TITLE
Generate icechunk repositories from sample data

### DIFF
--- a/tests/test_backup_generation.py
+++ b/tests/test_backup_generation.py
@@ -1,0 +1,24 @@
+import numpy as np
+from pathlib import Path
+
+from tests.helpers import open_test_dataset
+
+
+def test_generated_repositories_structure(blob_root: Path, generated_repos: list[Path]):
+    ds = open_test_dataset()
+    instrument = ds.attrs["instrument"]
+    project = ds.attrs["project"]
+    base_dir = blob_root / instrument / project
+
+    assert base_dir.exists()
+    assert len(generated_repos) == 2
+
+    date = np.datetime_as_string(ds["timestamp"].values[0], unit="D").replace("-", "")
+    expected = [
+        base_dir / f"{date}_{int(ds.attrs['gas_id']) + i}_{int(ds.attrs['gas_version']) + i}"
+        for i in range(2)
+    ]
+
+    assert sorted(generated_repos) == sorted(expected)
+    for path in expected:
+        assert path.is_dir()


### PR DESCRIPTION
## Summary
- add helpers to build backup paths and create icechunk repositories from sample Zarr data
- create session fixtures to pre-populate test backup repositories
- add test verifying repository naming and structure

## Testing
- `pytest tests/test_azurite_service.py::test_azurite_basic_operations -vv` *(fails: KeyboardInterrupt)*
- `pytest` *(fails: test_azurite_service.py::test_azurite_basic_operations, test_azurite_service.py::test_azure_fsspec)*

------
https://chatgpt.com/codex/tasks/task_e_689f754fdb40832f80252317d18acfde