### PR TITLE
Refactor minimal upload tests

### DIFF
--- a/tests/test_minimal_upload.py
+++ b/tests/test_minimal_upload.py
@@ -1,22 +1,24 @@
 import os
-import numpy as np
-import xarray as xr
-import icechunk
-import icechunk.xarray as icx  # added
-
-from ice_stream.blocks import select_minimal_variables, upload_single_chunk, clean_dataset
-from tests.helpers import AzuriteStorageClient, open_test_dataset, total_sent_bytes  # added
-import icechunk as ic
-from icechunk import ManifestSplitCondition, ManifestSplittingConfig, ManifestSplitDimCondition
 import datetime
+import numpy as np
+import pytest
+import xarray as xr
+
+import icechunk
+import icechunk.xarray as icx
+
+from ice_stream.blocks import clean_dataset, select_minimal_variables, upload_single_chunk
+from icechunk import (
+    ManifestSplitCondition,
+    ManifestSplittingConfig,
+    ManifestSplitDimCondition,
+)
+from tests.helpers import AzuriteStorageClient, open_test_dataset, total_sent_bytes
+
 
 def _extend_to_hours(ds: xr.Dataset, hours: int = 1) -> xr.Dataset:
-    """Extend dataset to cover *hours* along the timestamp dimension.
+    """Extend dataset to cover *hours* along the timestamp dimension."""
 
-    The dataset may be repeated to exceed the requested duration and is
-    then trimmed so that the returned data spans approximately *hours*
-    hours starting from the first timestamp.
-    """
     t = ds["timestamp"].values
     span = (t[-1] - t[0]) + (t[1] - t[0])
     target = np.timedelta64(hours, "h")
@@ -34,25 +36,14 @@ def _extend_to_hours(ds: xr.Dataset, hours: int = 1) -> xr.Dataset:
     return extended.sel(timestamp=slice(None, end_time))
 
 
-
-def test_full_day_single_shot_upload(artifacts) -> None:
-    ds = open_test_dataset()
-    ds_min = ds
-    ds_day = _extend_to_hours(ds_min, hours=24)
-
-    container = "minimal-day-container"
-    prefix = "minimal-day-prefix"
+def _setup_repo(container: str, prefix: str, repo_config: icechunk.RepositoryConfig | None = None):
     client = AzuriteStorageClient()
     client.container_name = container
     try:
         client.blob_service_client.delete_container(container)
     except Exception:
         pass
-    
     client.create_container()
-    
-    start_sent = total_sent_bytes()
-
     storage = icechunk.azure_storage(
         account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
         container=container,
@@ -60,147 +51,92 @@ def test_full_day_single_shot_upload(artifacts) -> None:
         from_env=True,
         config={"azure_storage_use_emulator": "true", "azure_allow_http": "true"},
     )
-    repo = icechunk.Repository.create(storage)
+    repo = icechunk.Repository.create(storage, config=repo_config) if repo_config else icechunk.Repository.create(storage)
+    return repo, client, storage
 
-    # measure bytes sent
-    upload_single_chunk(repo, ds_day)
+
+def _log_stats(
+    ds: xr.Dataset,
+    artifacts,
+    client: AzuriteStorageClient,
+    container: str,
+    prefix: str,
+    start_sent: int,
+    repo: icechunk.Repository | None = None,
+    name: str = "blob_size.txt",
+) -> None:
     used_sent = max(0, total_sent_bytes() - start_sent)
-
     container_client = client.blob_service_client.get_container_client(container)
     total_bytes = sum(blob.size for blob in container_client.list_blobs(name_starts_with=prefix))
     size_mb = total_bytes / (1024 * 1024)
-    num_timestamps = int(ds_day.sizes.get("timestamp", 0))
-    var_names = list(ds_day.data_vars)
-    dims_by_var = {v: {d: int(ds_day[v].sizes[d]) for d in ds_day[v].dims} for v in var_names}
-    info_lines = [
-        f"total_bytes: {total_bytes}",
-        f"size_mb: {size_mb:.2f}",
-        f"sent_bytes: {used_sent}",
-        f"sent_mb: {used_sent/(1024*1024):.2f}",
-        f"num_timestamps: {num_timestamps}",
-        f"variables: {', '.join(var_names)}",
-        "dims_by_var:",
-    ]
+    num_timestamps = int(ds.sizes.get("timestamp", 0))
+    var_names = list(ds.data_vars)
+    dims_by_var = {v: {d: int(ds[v].sizes[d]) for d in ds[v].dims} for v in var_names}
+    lines = [f"size_mb: {size_mb:.2f}", f"sent_mb: {used_sent/(1024*1024):.2f}", f"num_timestamps: {num_timestamps}", f"variables: {', '.join(var_names)}", "dims_by_var:"]
+    if repo is not None:
+        ic_total_bytes = repo.total_chunks_storage()
+        lines.insert(0, f"ic_size_mb: {ic_total_bytes / (1024 * 1024):.2f}")
     for v in var_names:
-        dims_str = ", ".join(f"{d}={dims_by_var[v][d]}" for d in ds_day[v].dims)
-        info_lines.append(f"  - {v}: {dims_str}")
-    artifacts.save_text("blob_size.txt", "\n".join(info_lines) + "\n")
+        dims_str = ", ".join(f"{d}={dims_by_var[v][d]}" for d in ds[v].dims)
+        lines.append(f"  - {v}: {dims_str}")
+    artifacts.save_text(name, "\n".join(lines) + "\n")
     assert total_bytes > 0
 
 
-
-
-def test_minimal_day_upload(artifacts) -> None:
+@pytest.mark.parametrize("minimal", [False, True], ids=["full", "minimal"])
+def test_single_shot_upload(minimal: bool, artifacts) -> None:
     ds = open_test_dataset()
-    ds_min = select_minimal_variables(ds)
-    ds_day = _extend_to_hours(ds_min, hours=24)
+    if minimal:
+        ds = select_minimal_variables(ds)
+    ds_hour = _extend_to_hours(ds)
 
-    container = "minimal-day-container"
-    prefix = "minimal-day-prefix"
-    client = AzuriteStorageClient()
-    client.container_name = container
-    try:
-        client.blob_service_client.delete_container(container)
-    except Exception:
-        pass
-    
-    client.create_container()
-    
+    container = f"single-shot-{'min' if minimal else 'full'}-container"
+    prefix = "single-shot-prefix"
+    repo, client, _ = _setup_repo(container, prefix)
+
     start_sent = total_sent_bytes()
+    upload_single_chunk(repo, ds_hour)
 
-    storage = icechunk.azure_storage(
-        account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
-        container=container,
-        prefix=prefix,
-        from_env=True,
-        config={"azure_storage_use_emulator": "true", "azure_allow_http": "true"},
-    )
-    repo = icechunk.Repository.create(storage)
-
-    # measure bytes sent
-    upload_single_chunk(repo, ds_day)
-    used_sent = max(0, total_sent_bytes() - start_sent)
-
-    container_client = client.blob_service_client.get_container_client(container)
-    total_bytes = sum(blob.size for blob in container_client.list_blobs(name_starts_with=prefix))
-    size_mb = total_bytes / (1024 * 1024)
-    num_timestamps = int(ds_day.sizes.get("timestamp", 0))
-    var_names = list(ds_day.data_vars)
-    dims_by_var = {v: {d: int(ds_day[v].sizes[d]) for d in ds_day[v].dims} for v in var_names}
-    info_lines = [
-        f"total_bytes: {total_bytes}",
-        f"size_mb: {size_mb:.2f}",
-        f"sent_bytes: {used_sent}",
-        f"sent_mb: {used_sent/(1024*1024):.2f}",
-        f"num_timestamps: {num_timestamps}",
-        f"variables: {', '.join(var_names)}",
-        "dims_by_var:",
-    ]
-    for v in var_names:
-        dims_str = ", ".join(f"{d}={dims_by_var[v][d]}" for d in ds_day[v].dims)
-        info_lines.append(f"  - {v}: {dims_str}")
-    artifacts.save_text("blob_size.txt", "\n".join(info_lines) + "\n")
-    assert total_bytes > 0
+    _log_stats(ds_hour, artifacts, client, container, prefix, start_sent, name=f"blob_size_{'min' if minimal else 'full'}.txt")
 
 
-def test_minimal_day_chunked_upload_incremental(artifacts) -> None:
+def test_minimal_hour_chunked_upload_incremental(artifacts) -> None:
     """Upload minimal variables in fixed-size chunks, reopening the repo for each append."""
-    ds = open_test_dataset()
-    ds_min = select_minimal_variables(ds)
-    ds_day = _extend_to_hours(ds_min, hours=24)
-    ds_day = clean_dataset(ds_day)
 
-    # enforce fixed chunk size along timestamp dimension
+    ds = select_minimal_variables(open_test_dataset())
+    ds_hour = clean_dataset(_extend_to_hours(ds))
+
     chunk_size = 1_000
-    total_ts = ds_day.sizes["timestamp"]
+    total_ts = ds_hour.sizes["timestamp"]
     aligned_ts = (total_ts // chunk_size) * chunk_size
-    ds_day = ds_day.isel(timestamp=slice(0, aligned_ts))
+    ds_hour = ds_hour.isel(timestamp=slice(0, aligned_ts))
 
     encoding = {"timestamp": {"chunks": (chunk_size,)}}
-    for v in ds_day.data_vars:
-        if "timestamp" in ds_day[v].dims:
-            shape = ds_day[v].shape
+    for v in ds_hour.data_vars:
+        if "timestamp" in ds_hour[v].dims:
+            shape = ds_hour[v].shape
             encoding[v] = {"chunks": (chunk_size,) + shape[1:]}
 
-    container = "minimal-day-incremental-container"
-    prefix = "minimal-day-incremental-prefix"
-    client = AzuriteStorageClient()
-    client.container_name = container
-    try:
-        client.blob_service_client.delete_container(container)
-    except Exception:
-        pass
-    client.create_container()
+    container = "minimal-hour-incremental-container"
+    prefix = "minimal-hour-incremental-prefix"
+    repo, client, storage = _setup_repo(container, prefix)
 
-    # measure bytes sent across the whole incremental upload
     start_sent = total_sent_bytes()
 
-    storage = icechunk.azure_storage(
-        account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
-        container=container,
-        prefix=prefix,
-        from_env=True,
-        config={"azure_storage_use_emulator": "true", "azure_allow_http": "true"},
-    )
-
-    # First chunk: create repo (mode="w")
-    first_chunk = ds_day.isel(timestamp=slice(0, chunk_size))
-    repo = icechunk.Repository.create(storage)
+    first_chunk = ds_hour.isel(timestamp=slice(0, chunk_size))
     s = repo.writable_session("main")
     icx.to_icechunk(first_chunk, s, mode="w", encoding=encoding)
     s.commit("initial chunk")
 
     reopened = icechunk.Repository.open(storage)
-    # Subsequent chunks: reopen repo and append each time
     for start in range(chunk_size, aligned_ts, chunk_size):
         s2 = reopened.writable_session("main")
-        chunk = ds_day.isel(timestamp=slice(start, start + chunk_size))
+        chunk = ds_hour.isel(timestamp=slice(start, start + chunk_size))
         icx.to_icechunk(chunk, s2, mode="a-", append_dim="timestamp")
         s2.commit("append chunk")
 
-    used_sent = max(0, total_sent_bytes() - start_sent)
+    _log_stats(ds_hour, artifacts, client, container, prefix, start_sent, repo, name="blob_size_incremental.txt")
 
-    # verify stored chunking
     reopened = icechunk.Repository.open(storage)
     read_s = reopened.readonly_session("main")
     stored = xr.open_zarr(read_s.store, consolidated=False)
@@ -210,111 +146,52 @@ def test_minimal_day_chunked_upload_incremental(artifacts) -> None:
         if "timestamp" in stored[v].dims:
             assert stored[v].encoding.get("chunks")[0] == chunk_size
 
-    container_client = client.blob_service_client.get_container_client(container)
-    total_bytes = sum(blob.size for blob in container_client.list_blobs(name_starts_with=prefix))
-    size_mb = total_bytes / (1024 * 1024)
 
-    # Icechunk reported total chunks storage (fallback to container size)
-    ic_total_bytes = repo.total_chunks_storage()
-    ic_size_mb = ic_total_bytes / (1024 * 1024)
+def test_minimal_hour_chunked_single_manifest_upload_incremental(artifacts) -> None:
+    """Upload minimal variables in fixed-size chunks with manifest splitting."""
 
-    num_timestamps = int(ds_day.sizes.get("timestamp", 0))
-    var_names = list(ds_day.data_vars)
-    dims_by_var = {v: {d: int(ds_day[v].sizes[d]) for d in ds_day[v].dims} for v in var_names}
-    lines = [
-        f"size_mb: {size_mb:.2f}",
-        f"ic_size_mb: {ic_size_mb:.2f}",
-        f"sent_mb: {used_sent/(1024*1024):.2f}",
-        f"num_timestamps: {num_timestamps}",
-        f"variables: {', '.join(var_names)}",
-        "dims_by_var:",
-    ]
-    for v in var_names:
-        dims_str = ", ".join(f"{d}={dims_by_var[v][d]}" for d in ds_day[v].dims)
-        lines.append(f"  - {v}: {dims_str}")
-    artifacts.save_text("blob_size_incremental.txt", "\n".join(lines) + "\n")
+    ds = select_minimal_variables(open_test_dataset())
+    ds_hour = clean_dataset(_extend_to_hours(ds))
 
-    assert total_bytes > 0
-
-
-
-
-def test_minimal_day_chunked_single_manifest_upload_incremental(artifacts) -> None:
-    """Upload minimal variables in fixed-size chunks, reopening the repo for each append."""
-    ds = open_test_dataset()
-    ds_min = select_minimal_variables(ds)
-    ds_day = _extend_to_hours(ds_min, hours=24)
-    ds_day = clean_dataset(ds_day)
-
-    # enforce fixed chunk size along timestamp dimension
     chunk_size = 1_000
-    total_ts = ds_day.sizes["timestamp"]
+    total_ts = ds_hour.sizes["timestamp"]
     aligned_ts = (total_ts // chunk_size) * chunk_size
-    ds_day = ds_day.isel(timestamp=slice(0, aligned_ts))
+    ds_hour = ds_hour.isel(timestamp=slice(0, aligned_ts))
 
     encoding = {"timestamp": {"chunks": (chunk_size,)}}
-    for v in ds_day.data_vars:
-        if "timestamp" in ds_day[v].dims:
-            shape = ds_day[v].shape
+    for v in ds_hour.data_vars:
+        if "timestamp" in ds_hour[v].dims:
+            shape = ds_hour[v].shape
             encoding[v] = {"chunks": (chunk_size,) + shape[1:]}
 
-    container = "minimal-day-incremental-container"
-    prefix = "minimal-day-incremental-prefix"
-    client = AzuriteStorageClient()
-    client.container_name = container
-    try:
-        client.blob_service_client.delete_container(container)
-    except Exception:
-        pass
-    client.create_container()
+    split_config = ManifestSplittingConfig.from_dict(
+        {ManifestSplitCondition.AnyArray(): {ManifestSplitDimCondition.DimensionName("timestamp"): 1}}
+    )
+    repo_config = icechunk.RepositoryConfig(manifest=icechunk.ManifestConfig(splitting=split_config))
 
-    # measure bytes sent across the whole incremental upload
+    container = "minimal-hour-manifest-container"
+    prefix = "minimal-hour-manifest-prefix"
+    repo, client, storage = _setup_repo(container, prefix, repo_config)
+
     start_sent = total_sent_bytes()
 
-
-    split_config = ManifestSplittingConfig.from_dict(
-        {
-            ManifestSplitCondition.AnyArray(): {
-                ManifestSplitDimCondition.DimensionName("timestamp"): 1
-            }
-        }
-    )
-    repo_config = ic.RepositoryConfig(
-        manifest=ic.ManifestConfig(splitting=split_config),
-    )
-
-
-    storage = icechunk.azure_storage(
-        account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
-        container=container,
-        prefix=prefix,
-        from_env=True,
-        config={"azure_storage_use_emulator": "true", "azure_allow_http": "true"},
-    )
-
-    # First chunk: create repo (mode="w")
-    first_chunk = ds_day.isel(timestamp=slice(0, chunk_size))
-    repo = icechunk.Repository.create(storage, config=repo_config)
+    first_chunk = ds_hour.isel(timestamp=slice(0, chunk_size))
     s = repo.writable_session("main")
     icx.to_icechunk(first_chunk, s, mode="w", encoding=encoding)
     s.commit("initial chunk")
 
     reopened = icechunk.Repository.open(storage, config=repo_config)
-    # Subsequent chunks: reopen repo and append each time
     for start in range(chunk_size, aligned_ts, chunk_size):
         s2 = reopened.writable_session("main")
-        chunk = ds_day.isel(timestamp=slice(start, start + chunk_size))
+        chunk = ds_hour.isel(timestamp=slice(start, start + chunk_size))
         icx.to_icechunk(chunk, s2, mode="a-", append_dim="timestamp")
         s2.commit("append chunk")
-
 
     repo.expire_snapshots(older_than=datetime.datetime.now(tz=datetime.UTC))
     repo.garbage_collect(datetime.datetime.now(tz=datetime.UTC))
 
+    _log_stats(ds_hour, artifacts, client, container, prefix, start_sent, repo, name="blob_size_incremental.txt")
 
-    used_sent = max(0, total_sent_bytes() - start_sent)
-
-    # verify stored chunking
     reopened = icechunk.Repository.open(storage)
     read_s = reopened.readonly_session("main")
     stored = xr.open_zarr(read_s.store, consolidated=False)
@@ -324,82 +201,33 @@ def test_minimal_day_chunked_single_manifest_upload_incremental(artifacts) -> No
         if "timestamp" in stored[v].dims:
             assert stored[v].encoding.get("chunks")[0] == chunk_size
 
-    container_client = client.blob_service_client.get_container_client(container)
-    total_bytes = sum(blob.size for blob in container_client.list_blobs(name_starts_with=prefix))
-    size_mb = total_bytes / (1024 * 1024)
 
-    # Icechunk reported total chunks storage (fallback to container size)
-    ic_total_bytes = repo.total_chunks_storage()
-    ic_size_mb = ic_total_bytes / (1024 * 1024)
+def test_minimal_hour_timed_single_manifest_upload_incremental(artifacts) -> None:
+    """Upload minimal variables in 15-minute increments."""
 
-    num_timestamps = int(ds_day.sizes.get("timestamp", 0))
-    var_names = list(ds_day.data_vars)
-    dims_by_var = {v: {d: int(ds_day[v].sizes[d]) for d in ds_day[v].dims} for v in var_names}
-    lines = [
-        f"size_mb: {size_mb:.2f}",
-        f"ic_size_mb: {ic_size_mb:.2f}",
-        f"sent_mb: {used_sent/(1024*1024):.2f}",
-        f"num_timestamps: {num_timestamps}",
-        f"variables: {', '.join(var_names)}",
-        "dims_by_var:",
-    ]
-    for v in var_names:
-        dims_str = ", ".join(f"{d}={dims_by_var[v][d]}" for d in ds_day[v].dims)
-        lines.append(f"  - {v}: {dims_str}")
-    artifacts.save_text("blob_size_incremental.txt", "\n".join(lines) + "\n")
+    ds = select_minimal_variables(open_test_dataset())
+    ds_hour = clean_dataset(_extend_to_hours(ds))
 
-    assert total_bytes > 0
+    container = "minimal-hour-timed-container"
+    prefix = "minimal-hour-timed-prefix"
+    repo, client, storage = _setup_repo(container, prefix)
 
-
-
-def test_minimal_day_timed_single_manifest_upload_incremental(artifacts) -> None:
-    """Upload minimal variables in 15-minute increments, reopening the repo for each append."""
-    ds = open_test_dataset()
-    ds_min = select_minimal_variables(ds)
-    ds_day = _extend_to_hours(ds_min, hours=24)
-    ds_day = clean_dataset(ds_day)
-
-    container = "minimal-day-incremental-container"
-    prefix = "minimal-day-incremental-prefix"
-    client = AzuriteStorageClient()
-    client.container_name = container
-    try:
-        client.blob_service_client.delete_container(container)
-    except Exception:
-        pass
-    client.create_container()
-
-    # measure bytes sent across the whole incremental upload
     start_sent = total_sent_bytes()
 
-
-    storage = icechunk.azure_storage(
-        account=os.environ["AZURE_STORAGE_ACCOUNT_NAME"],
-        container=container,
-        prefix=prefix,
-        from_env=True,
-        config={"azure_storage_use_emulator": "true", "azure_allow_http": "true"},
-    )
-
-    # Build 15-minute windows over the timestamp axis
-    ts = ds_day["timestamp"].values
+    ts = ds_hour["timestamp"].values
     step = np.timedelta64(15, "m")
     t0 = ts[0]
     t_last = ts[-1]
 
-    # First window: [t0, t0+15m] inclusive
     first_end = min(t0 + step, t_last)
     first_end_idx = int(np.searchsorted(ts, first_end, side="right"))
-    first_chunk = ds_day.isel(timestamp=slice(0, first_end_idx))
+    first_chunk = ds_hour.isel(timestamp=slice(0, first_end_idx))
 
-    repo = icechunk.Repository.create(storage, )
     s = repo.writable_session("main")
     icx.to_icechunk(first_chunk, s, mode="w")
     s.commit("initial 15-minute window")
 
     reopened = icechunk.Repository.open(storage)
-
-    # Subsequent windows: (prev_end, prev_end+15m] to avoid duplicating boundary timestamps
     cur_start = first_end
     while cur_start < t_last:
         cur_end = cur_start + step
@@ -408,45 +236,16 @@ def test_minimal_day_timed_single_manifest_upload_incremental(artifacts) -> None
         start_idx = int(np.searchsorted(ts, cur_start, side="right"))
         end_idx = int(np.searchsorted(ts, cur_end, side="right"))
         if end_idx > start_idx:
-            chunk = ds_day.isel(timestamp=slice(start_idx, end_idx))
+            chunk = ds_hour.isel(timestamp=slice(start_idx, end_idx))
             s2 = reopened.writable_session("main")
             icx.to_icechunk(chunk, s2, mode="a-", append_dim="timestamp")
             s2.commit("append 15-minute window")
         cur_start = cur_end
 
-    used_sent = max(0, total_sent_bytes() - start_sent)
+    _log_stats(ds_hour, artifacts, client, container, prefix, start_sent, repo, name="blob_size_incremental.txt")
 
-    # verify stored data length (no chunk encoding assertions)
     reopened = icechunk.Repository.open(storage)
     read_s = reopened.readonly_session("main")
     stored = xr.open_zarr(read_s.store, consolidated=False)
-    assert stored.sizes["timestamp"] == ds_day.sizes["timestamp"]
-
-    container_client = client.blob_service_client.get_container_client(container)
-    total_bytes = sum(blob.size for blob in container_client.list_blobs(name_starts_with=prefix))
-    size_mb = total_bytes / (1024 * 1024)
-
-    # Icechunk reported total chunks storage (fallback to container size)
-    ic_total_bytes = repo.total_chunks_storage()
-    ic_size_mb = ic_total_bytes / (1024 * 1024)
-
-    num_timestamps = int(ds_day.sizes.get("timestamp", 0))
-    var_names = list(ds_day.data_vars)
-    dims_by_var = {v: {d: int(ds_day[v].sizes[d]) for d in ds_day[v].dims} for v in var_names}
-    lines = [
-        f"size_mb: {size_mb:.2f}",
-        f"ic_size_mb: {ic_size_mb:.2f}",
-        f"sent_mb: {used_sent/(1024*1024):.2f}",
-        f"num_timestamps: {num_timestamps}",
-        f"variables: {', '.join(var_names)}",
-        "dims_by_var:",
-    ]
-    for v in var_names:
-        dims_str = ", ".join(f"{d}={dims_by_var[v][d]}" for d in ds_day[v].dims)
-        lines.append(f"  - {v}: {dims_str}")
-    artifacts.save_text("blob_size_incremental.txt", "\n".join(lines) + "\n")
-
-    assert total_bytes > 0
-
-
+    assert stored.sizes["timestamp"] == ds_hour.sizes["timestamp"]
 


### PR DESCRIPTION
## Summary
- reduce duplicated logic in minimal upload tests
- limit dataset expansion to one hour for faster execution
- add helpers for repo setup and stats logging

## Testing
- `pytest` *(fails: tests/test_azurite_service.py::test_azure_repo_append_waveform_highfreq - ValueError: variable 'c1' already exists, but variable 'c1' with different dtype already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68a2176f2128832fae54ea37738fb460